### PR TITLE
Fixed #114: Datastreams have a unitOfMeasurement field, not ObservedP…

### DIFF
--- a/src/18-088/09_service_interface.adoc
+++ b/src/18-088/09_service_interface.adoc
@@ -828,11 +828,11 @@ Req <<req-request-data-built-in-filter-operations>>: <<requirement-request-data-
 
 |eq
 |Equal
-|`+/ObservedProperties?$filter=unitOfMeasurement/name eq 'degree Celsius'+`
+|`+/Datastreams?$filter=unitOfMeasurement/name eq 'degree Celsius'+`
 
 |ne
 |Not equal
-|`+/ObservedProperties?$filter=unitOfMeasurement/name ne 'degree Celsius'+`
+|`+/Datastreams?$filter=unitOfMeasurement/name ne 'degree Celsius'+`
 
 |gt
 |Greater than


### PR DESCRIPTION
This PR fixes a mistake in two of the examples.
