### PR TITLE
18-088: Fixed leftover 1.0 references

### DIFF
--- a/src/18-088/08_entities.adoc
+++ b/src/18-088/08_entities.adoc
@@ -6,37 +6,37 @@ This chapter describes the SensorThings API data model. All data model requireme
 |===
 2+|Requirements Class
 
-2+|\http://www.opengis.net/spec/iot_sensing/1.0/req/datamodel
+2+|\http://www.opengis.net/spec/iot_sensing/1.1/req/datamodel
 
 |Target Type
 |Web Service
 
 |Requirements class
-|\http://www.opengis.net/spec/iot_sensing/1.0/req/datamodel/entity-control-information
+|\http://www.opengis.net/spec/iot_sensing/1.1/req/datamodel/entity-control-information
 
 |Requirements class
-|\http://www.opengis.net/spec/iot_sensing/1.0/req/datamodel/thing
+|\http://www.opengis.net/spec/iot_sensing/1.1/req/datamodel/thing
 
 |Requirements class
-|\http://www.opengis.net/spec/iot_sensing/1.0/req/datamodel/location
+|\http://www.opengis.net/spec/iot_sensing/1.1/req/datamodel/location
 
 |Requirements class
-|\http://www.opengis.net/spec/iot_sensing/1.0/req/datamodel/historical-location
+|\http://www.opengis.net/spec/iot_sensing/1.1/req/datamodel/historical-location
 
 |Requirements class
-|\http://www.opengis.net/spec/iot_sensing/1.0/req/datamodel/datastream
+|\http://www.opengis.net/spec/iot_sensing/1.1/req/datamodel/datastream
 
 |Requirements class
-|\http://www.opengis.net/spec/iot_sensing/1.0/req/datamodel/sensor
+|\http://www.opengis.net/spec/iot_sensing/1.1/req/datamodel/sensor
 
 |Requirements class
-|\http://www.opengis.net/spec/iot_sensing/1.0/req/datamodel/observed-property
+|\http://www.opengis.net/spec/iot_sensing/1.1/req/datamodel/observed-property
 
 |Requirements class
-|\http://www.opengis.net/spec/iot_sensing/1.0/req/datamodel/observation
+|\http://www.opengis.net/spec/iot_sensing/1.1/req/datamodel/observation
 
 |Requirements class
-|\http://www.opengis.net/spec/iot_sensing/1.0/req/datamodel/feature-of-interest
+|\http://www.opengis.net/spec/iot_sensing/1.1/req/datamodel/feature-of-interest
 |===
 
 
@@ -437,7 +437,7 @@ The HistoricalLocation can also be created, updated and deleted. One use case is
 Req <<req-create-update-delete-historical-location-manual-creation>>: <<requirement-create-update-delete-historical-location-manual-creation>>
 
 |When a user directly adds new HistoricalLocation, and the time of this new HistoricalLocation is later than the latest HistoricalLocation for the Thing, then the Locations of the Thing are changed to the Locations of this new HistoricalLocation.
-|\http://www.opengis.net/spec/iot_sensing/1.0/req/<<requirement-create-update-delete-historical-location-manual-creation>>
+|\http://www.opengis.net/spec/iot_sensing/1.1/req/<<requirement-create-update-delete-historical-location-manual-creation>>
 |===
 
 

--- a/src/18-088/10_create_update_delete.adoc
+++ b/src/18-088/10_create_update_delete.adoc
@@ -318,7 +318,7 @@ Req <<req-create-update-delete-update-entity>>: <<requirement-create-update-dele
 Req <<req-create-update-delete-update-entity-put>>: <<requirement-create-update-delete-update-entity-put>>
 
 |A SensorThings service that supports updates with PUT SHALL follow the requirements as defined in <<update-entity>>.
-|\http://www.opengis.net/spec/iot_sensing/1.0/req/<<requirement-create-update-delete-update-entity-put>>
+|\http://www.opengis.net/spec/iot_sensing/1.1/req/<<requirement-create-update-delete-update-entity-put>>
 |===
 
 [[req-create-update-delete-update-entity-jsonpatch,{counter:req11}]]
@@ -328,7 +328,7 @@ Req <<req-create-update-delete-update-entity-put>>: <<requirement-create-update-
 Req <<req-create-update-delete-update-entity-jsonpatch>>: <<requirement-create-update-delete-update-entity-jsonpatch>>
 
 |A SensorThings service that supports updates with the JSON PATCH format SHALL follow the requirements as defined in <<update-entity>>.
-|\http://www.opengis.net/spec/iot_sensing/1.0/req/<<requirement-create-update-delete-update-entity-jsonpatch>>
+|\http://www.opengis.net/spec/iot_sensing/1.1/req/<<requirement-create-update-delete-update-entity-jsonpatch>>
 |===
 
 

--- a/src/18-088/14_mqtt.adoc
+++ b/src/18-088/14_mqtt.adoc
@@ -4,8 +4,8 @@
 In addition to support HTTP protocol, a SensorThings service MAY support MQTT protocol to enhance the SensorThings service publish and subscribe capabilities. This section describes the SensorThings MQTT extension. To help a client find the MQTT endpoints of a SensorThings service, the endpoints of the service are documented in the `+serverSettings+` object of the landing page described in <<usage-no-resource-path>>. If the service supports the MQTT extension, then the `+serverSettings+` object SHALL contain properties of type Object, with the names
 
 ----
-http://www.opengis.net/spec/iot_sensing/1.0/req/receive-updates-via-mqtt/receive-updates
-http://www.opengis.net/spec/iot_sensing/1.0/req/create-observations-via-mqtt/observations-creation
+http://www.opengis.net/spec/iot_sensing/1.1/req/receive-updates-via-mqtt/receive-updates
+http://www.opengis.net/spec/iot_sensing/1.1/req/create-observations-via-mqtt/observations-creation
 ----
 
 These Objects SHALL contain a property named `+endpoints+` of type Array. The JSON Array `+endpoints+` SHALL hold a list of URL Schemes that can be used to connect to the MQTT service, as seen in example 10 in <<usage-no-resource-path>>. If the service supports both update-notification and observation-creation over MQTT, it may use different endpoints for the two services.


### PR DESCRIPTION
Since I build a document parser for the OMSv3 spec, I figured I'd run it on our STAv2 spec... and of course I found some leftover 1.0 references.
This PR fixes those.