### PR TITLE
docs: Add RIVM Air Quality endpoint.

### DIFF
--- a/PublicEndPoints.md
+++ b/PublicEndPoints.md
@@ -16,6 +16,7 @@ If you maintain a SensorThings service and would like to add it to the list, let
 | County | Owner | Domain | Info | Endpoint URL |
 | --- | --- | --- | --- | --- |
 |Europe | Fraunhofer IOSB | Air Quality | [info](https://datacoveeu.github.io/API4INSPIRE/datanests/ad-hoc.html) | https://airquality-frost.k8s.ilt-dmz.iosb.fraunhofer.de/v1.1/ |
+|Netherlands | RIVM| Air Quality | [info](https://www.samenmeten.nl/dataportaal/api-application-programming-interface) | https://api-samenmeten.rivm.nl/v1.0/ |
 
 
 ## Statistics


### PR DESCRIPTION
Small PR to add the public dutch endpoint for Air Quality sensors.

Dashboard is here:
https://samenmeten.rivm.nl/dataportaal/

API is here:
https://api-samenmeten.rivm.nl/v1.0/

Description is here (dutch):
https://www.samenmeten.nl/dataportaal/api-application-programming-interface